### PR TITLE
fix: [cherry-pick] update google/protobuf v4.33.4 -> v4.33.6 (GHSA-p2gh-cfq4-4wjc)

### DIFF
--- a/8.1/composer.lock
+++ b/8.1/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "36189ac3bdb1c95d7ee39221a8071b79",
+  "content-hash": "6d9796760e82074eca05f3abfad9f860",
   "packages": [
     {
       "name": "bower-asset/inputmask",
@@ -1110,23 +1110,23 @@
     },
     {
       "name": "google/protobuf",
-      "version": "v4.33.4",
+      "version": "v4.33.6",
       "source": {
         "type": "git",
         "url": "https://github.com/protocolbuffers/protobuf-php.git",
-        "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402"
+        "reference": "84b008c23915ed94536737eae46f41ba3bccfe67"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/22d28025cda0d223a2e48c2e16c5284ecc9f5402",
-        "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402",
+        "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/84b008c23915ed94536737eae46f41ba3bccfe67",
+        "reference": "84b008c23915ed94536737eae46f41ba3bccfe67",
         "shasum": ""
       },
       "require": {
         "php": ">=8.1.0"
       },
       "require-dev": {
-        "phpunit/phpunit": ">=5.0.0 <8.5.27"
+        "phpunit/phpunit": ">=10.5.62 <11.0.0"
       },
       "suggest": {
         "ext-bcmath": "Need to support JSON deserialization"
@@ -1148,9 +1148,9 @@
         "proto"
       ],
       "support": {
-        "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.4"
+        "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.6"
       },
-      "time": "2026-01-12T17:58:43+00:00"
+      "time": "2026-03-18T17:32:05+00:00"
     },
     {
       "name": "graham-campbell/result-type",
@@ -8987,8 +8987,5 @@
     "ext-opentelemetry": "*"
   },
   "platform-dev": {},
-  "platform-overrides": {
-    "php": "8.1.99"
-  },
   "plugin-api-version": "2.9.0"
 }

--- a/8.1/vendor/composer/installed.json
+++ b/8.1/vendor/composer/installed.json
@@ -1158,29 +1158,29 @@
         },
         {
             "name": "google/protobuf",
-            "version": "v4.33.4",
-            "version_normalized": "4.33.4.0",
+            "version": "v4.33.6",
+            "version_normalized": "4.33.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402"
+                "reference": "84b008c23915ed94536737eae46f41ba3bccfe67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/22d28025cda0d223a2e48c2e16c5284ecc9f5402",
-                "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/84b008c23915ed94536737eae46f41ba3bccfe67",
+                "reference": "84b008c23915ed94536737eae46f41ba3bccfe67",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=5.0.0 <8.5.27"
+                "phpunit/phpunit": ">=10.5.62 <11.0.0"
             },
             "suggest": {
                 "ext-bcmath": "Need to support JSON deserialization"
             },
-            "time": "2026-01-12T17:58:43+00:00",
+            "time": "2026-03-18T17:32:05+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -1199,7 +1199,7 @@
                 "proto"
             ],
             "support": {
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.4"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.6"
             },
             "install-path": "../google/protobuf"
         },

--- a/8.1/vendor/composer/installed.php
+++ b/8.1/vendor/composer/installed.php
@@ -257,9 +257,9 @@
             'dev_requirement' => false,
         ),
         'google/protobuf' => array(
-            'pretty_version' => 'v4.33.4',
-            'version' => '4.33.4.0',
-            'reference' => '22d28025cda0d223a2e48c2e16c5284ecc9f5402',
+            'pretty_version' => 'v4.33.6',
+            'version' => '4.33.6.0',
+            'reference' => '84b008c23915ed94536737eae46f41ba3bccfe67',
             'type' => 'library',
             'install_path' => __DIR__ . '/../google/protobuf',
             'aliases' => array(),

--- a/8.1/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedInputStream.php
+++ b/8.1/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedInputStream.php
@@ -237,7 +237,8 @@ class CodedInputStream
     public function readRaw($size, &$buffer)
     {
         $current_buffer_size = 0;
-        if ($this->bufferSize() < $size) {
+        // size (varint) read from the wire could be negative.
+        if ($size < 0 || $this->bufferSize() < $size) {
             return \false;
         }
         if ($size === 0) {
@@ -293,7 +294,7 @@ class CodedInputStream
     public function incrementRecursionDepthAndPushLimit($byte_limit, &$old_limit, &$recursion_budget)
     {
         $old_limit = $this->pushLimit($byte_limit);
-        $recursion_limit = --$this->recursion_limit;
+        $recursion_budget = --$this->recursion_budget;
     }
     public function decrementRecursionDepthAndPopLimit($byte_limit)
     {

--- a/8.1/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedOutputStream.php
+++ b/8.1/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedOutputStream.php
@@ -82,7 +82,7 @@ class CodedOutputStream
             $low = $value;
         }
         while ($low >= 0x80 || $low < 0 || $high != 0) {
-            $buffer[$current] = chr($low | 0x80);
+            $buffer[$current] = chr(($low | 0x80) & 0xFF);
             $value = $value >> 7 & ~(0x7f << (\PHP_INT_SIZE << 3) - 7);
             $carry = ($high & 0x7f) << (\PHP_INT_SIZE << 3) - 7;
             $high = $high >> 7 & ~(0x7f << (\PHP_INT_SIZE << 3) - 7);

--- a/8.1/vendor/google/protobuf/src/Google/Protobuf/Internal/Descriptor.php
+++ b/8.1/vendor/google/protobuf/src/Google/Protobuf/Internal/Descriptor.php
@@ -46,7 +46,7 @@ class Descriptor
     public function addField($field)
     {
         $this->field[$field->getNumber()] = $field;
-        $this->json_to_field[$field->getJsonName()] = $field;
+        $this->json_to_field[$field->getJsonName() ?? ''] = $field;
         $this->name_to_field[$field->getName()] = $field;
         $this->index_to_field[] = $field;
     }

--- a/8.1/vendor/google/protobuf/src/Google/Protobuf/Internal/DescriptorPool.php
+++ b/8.1/vendor/google/protobuf/src/Google/Protobuf/Internal/DescriptorPool.php
@@ -62,8 +62,8 @@ class DescriptorPool
         $this->proto_to_class[$descriptor->getFullName()] = $descriptor->getClass();
         $this->unique_descs[$descriptor->getFullName()] = $descriptor;
         $this->class_to_desc[$descriptor->getClass()] = $descriptor;
-        $this->class_to_desc[$descriptor->getLegacyClass()] = $descriptor;
-        $this->class_to_desc[$descriptor->getPreviouslyUnreservedClass()] = $descriptor;
+        $this->class_to_desc[$descriptor->getLegacyClass() ?? ''] = $descriptor;
+        $this->class_to_desc[$descriptor->getPreviouslyUnreservedClass() ?? ''] = $descriptor;
         foreach ($descriptor->getNestedType() as $nested_type) {
             $this->addDescriptor($nested_type);
         }
@@ -75,7 +75,7 @@ class DescriptorPool
     {
         $this->proto_to_class[$descriptor->getFullName()] = $descriptor->getClass();
         $this->class_to_enum_desc[$descriptor->getClass()] = $descriptor;
-        $this->class_to_enum_desc[$descriptor->getLegacyClass()] = $descriptor;
+        $this->class_to_enum_desc[$descriptor->getLegacyClass() ?? ''] = $descriptor;
     }
     public function getDescriptorByClassName($klass)
     {

--- a/8.2/composer.lock
+++ b/8.2/composer.lock
@@ -1264,23 +1264,23 @@
     },
     {
       "name": "google/protobuf",
-      "version": "v4.33.4",
+      "version": "v4.33.6",
       "source": {
         "type": "git",
         "url": "https://github.com/protocolbuffers/protobuf-php.git",
-        "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402"
+        "reference": "84b008c23915ed94536737eae46f41ba3bccfe67"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/22d28025cda0d223a2e48c2e16c5284ecc9f5402",
-        "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402",
+        "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/84b008c23915ed94536737eae46f41ba3bccfe67",
+        "reference": "84b008c23915ed94536737eae46f41ba3bccfe67",
         "shasum": ""
       },
       "require": {
         "php": ">=8.1.0"
       },
       "require-dev": {
-        "phpunit/phpunit": ">=5.0.0 <8.5.27"
+        "phpunit/phpunit": ">=10.5.62 <11.0.0"
       },
       "suggest": {
         "ext-bcmath": "Need to support JSON deserialization"
@@ -1302,9 +1302,9 @@
         "proto"
       ],
       "support": {
-        "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.4"
+        "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.6"
       },
-      "time": "2026-01-12T17:58:43+00:00"
+      "time": "2026-03-18T17:32:05+00:00"
     },
     {
       "name": "graham-campbell/result-type",

--- a/8.2/vendor/composer/installed.json
+++ b/8.2/vendor/composer/installed.json
@@ -1318,29 +1318,29 @@
         },
         {
             "name": "google/protobuf",
-            "version": "v4.33.4",
-            "version_normalized": "4.33.4.0",
+            "version": "v4.33.6",
+            "version_normalized": "4.33.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402"
+                "reference": "84b008c23915ed94536737eae46f41ba3bccfe67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/22d28025cda0d223a2e48c2e16c5284ecc9f5402",
-                "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/84b008c23915ed94536737eae46f41ba3bccfe67",
+                "reference": "84b008c23915ed94536737eae46f41ba3bccfe67",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=5.0.0 <8.5.27"
+                "phpunit/phpunit": ">=10.5.62 <11.0.0"
             },
             "suggest": {
                 "ext-bcmath": "Need to support JSON deserialization"
             },
-            "time": "2026-01-12T17:58:43+00:00",
+            "time": "2026-03-18T17:32:05+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -1359,7 +1359,7 @@
                 "proto"
             ],
             "support": {
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.4"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.6"
             },
             "install-path": "../google/protobuf"
         },

--- a/8.2/vendor/composer/installed.php
+++ b/8.2/vendor/composer/installed.php
@@ -275,9 +275,9 @@
             'dev_requirement' => false,
         ),
         'google/protobuf' => array(
-            'pretty_version' => 'v4.33.4',
-            'version' => '4.33.4.0',
-            'reference' => '22d28025cda0d223a2e48c2e16c5284ecc9f5402',
+            'pretty_version' => 'v4.33.6',
+            'version' => '4.33.6.0',
+            'reference' => '84b008c23915ed94536737eae46f41ba3bccfe67',
             'type' => 'library',
             'install_path' => __DIR__ . '/../google/protobuf',
             'aliases' => array(),

--- a/8.2/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedInputStream.php
+++ b/8.2/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedInputStream.php
@@ -237,7 +237,8 @@ class CodedInputStream
     public function readRaw($size, &$buffer)
     {
         $current_buffer_size = 0;
-        if ($this->bufferSize() < $size) {
+        // size (varint) read from the wire could be negative.
+        if ($size < 0 || $this->bufferSize() < $size) {
             return \false;
         }
         if ($size === 0) {
@@ -293,7 +294,7 @@ class CodedInputStream
     public function incrementRecursionDepthAndPushLimit($byte_limit, &$old_limit, &$recursion_budget)
     {
         $old_limit = $this->pushLimit($byte_limit);
-        $recursion_limit = --$this->recursion_limit;
+        $recursion_budget = --$this->recursion_budget;
     }
     public function decrementRecursionDepthAndPopLimit($byte_limit)
     {

--- a/8.2/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedOutputStream.php
+++ b/8.2/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedOutputStream.php
@@ -82,7 +82,7 @@ class CodedOutputStream
             $low = $value;
         }
         while ($low >= 0x80 || $low < 0 || $high != 0) {
-            $buffer[$current] = chr($low | 0x80);
+            $buffer[$current] = chr(($low | 0x80) & 0xFF);
             $value = $value >> 7 & ~(0x7f << (\PHP_INT_SIZE << 3) - 7);
             $carry = ($high & 0x7f) << (\PHP_INT_SIZE << 3) - 7;
             $high = $high >> 7 & ~(0x7f << (\PHP_INT_SIZE << 3) - 7);

--- a/8.2/vendor/google/protobuf/src/Google/Protobuf/Internal/Descriptor.php
+++ b/8.2/vendor/google/protobuf/src/Google/Protobuf/Internal/Descriptor.php
@@ -46,7 +46,7 @@ class Descriptor
     public function addField($field)
     {
         $this->field[$field->getNumber()] = $field;
-        $this->json_to_field[$field->getJsonName()] = $field;
+        $this->json_to_field[$field->getJsonName() ?? ''] = $field;
         $this->name_to_field[$field->getName()] = $field;
         $this->index_to_field[] = $field;
     }

--- a/8.2/vendor/google/protobuf/src/Google/Protobuf/Internal/DescriptorPool.php
+++ b/8.2/vendor/google/protobuf/src/Google/Protobuf/Internal/DescriptorPool.php
@@ -62,8 +62,8 @@ class DescriptorPool
         $this->proto_to_class[$descriptor->getFullName()] = $descriptor->getClass();
         $this->unique_descs[$descriptor->getFullName()] = $descriptor;
         $this->class_to_desc[$descriptor->getClass()] = $descriptor;
-        $this->class_to_desc[$descriptor->getLegacyClass()] = $descriptor;
-        $this->class_to_desc[$descriptor->getPreviouslyUnreservedClass()] = $descriptor;
+        $this->class_to_desc[$descriptor->getLegacyClass() ?? ''] = $descriptor;
+        $this->class_to_desc[$descriptor->getPreviouslyUnreservedClass() ?? ''] = $descriptor;
         foreach ($descriptor->getNestedType() as $nested_type) {
             $this->addDescriptor($nested_type);
         }
@@ -75,7 +75,7 @@ class DescriptorPool
     {
         $this->proto_to_class[$descriptor->getFullName()] = $descriptor->getClass();
         $this->class_to_enum_desc[$descriptor->getClass()] = $descriptor;
-        $this->class_to_enum_desc[$descriptor->getLegacyClass()] = $descriptor;
+        $this->class_to_enum_desc[$descriptor->getLegacyClass() ?? ''] = $descriptor;
     }
     public function getDescriptorByClassName($klass)
     {

--- a/8.3/composer.lock
+++ b/8.3/composer.lock
@@ -1264,23 +1264,23 @@
     },
     {
       "name": "google/protobuf",
-      "version": "v4.33.4",
+      "version": "v4.33.6",
       "source": {
         "type": "git",
         "url": "https://github.com/protocolbuffers/protobuf-php.git",
-        "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402"
+        "reference": "84b008c23915ed94536737eae46f41ba3bccfe67"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/22d28025cda0d223a2e48c2e16c5284ecc9f5402",
-        "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402",
+        "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/84b008c23915ed94536737eae46f41ba3bccfe67",
+        "reference": "84b008c23915ed94536737eae46f41ba3bccfe67",
         "shasum": ""
       },
       "require": {
         "php": ">=8.1.0"
       },
       "require-dev": {
-        "phpunit/phpunit": ">=5.0.0 <8.5.27"
+        "phpunit/phpunit": ">=10.5.62 <11.0.0"
       },
       "suggest": {
         "ext-bcmath": "Need to support JSON deserialization"
@@ -1302,9 +1302,9 @@
         "proto"
       ],
       "support": {
-        "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.4"
+        "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.6"
       },
-      "time": "2026-01-12T17:58:43+00:00"
+      "time": "2026-03-18T17:32:05+00:00"
     },
     {
       "name": "graham-campbell/result-type",

--- a/8.3/vendor/composer/installed.json
+++ b/8.3/vendor/composer/installed.json
@@ -1318,29 +1318,29 @@
         },
         {
             "name": "google/protobuf",
-            "version": "v4.33.4",
-            "version_normalized": "4.33.4.0",
+            "version": "v4.33.6",
+            "version_normalized": "4.33.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402"
+                "reference": "84b008c23915ed94536737eae46f41ba3bccfe67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/22d28025cda0d223a2e48c2e16c5284ecc9f5402",
-                "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/84b008c23915ed94536737eae46f41ba3bccfe67",
+                "reference": "84b008c23915ed94536737eae46f41ba3bccfe67",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=5.0.0 <8.5.27"
+                "phpunit/phpunit": ">=10.5.62 <11.0.0"
             },
             "suggest": {
                 "ext-bcmath": "Need to support JSON deserialization"
             },
-            "time": "2026-01-12T17:58:43+00:00",
+            "time": "2026-03-18T17:32:05+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -1359,7 +1359,7 @@
                 "proto"
             ],
             "support": {
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.4"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.6"
             },
             "install-path": "../google/protobuf"
         },

--- a/8.3/vendor/composer/installed.php
+++ b/8.3/vendor/composer/installed.php
@@ -275,9 +275,9 @@
             'dev_requirement' => false,
         ),
         'google/protobuf' => array(
-            'pretty_version' => 'v4.33.4',
-            'version' => '4.33.4.0',
-            'reference' => '22d28025cda0d223a2e48c2e16c5284ecc9f5402',
+            'pretty_version' => 'v4.33.6',
+            'version' => '4.33.6.0',
+            'reference' => '84b008c23915ed94536737eae46f41ba3bccfe67',
             'type' => 'library',
             'install_path' => __DIR__ . '/../google/protobuf',
             'aliases' => array(),

--- a/8.3/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedInputStream.php
+++ b/8.3/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedInputStream.php
@@ -237,7 +237,8 @@ class CodedInputStream
     public function readRaw($size, &$buffer)
     {
         $current_buffer_size = 0;
-        if ($this->bufferSize() < $size) {
+        // size (varint) read from the wire could be negative.
+        if ($size < 0 || $this->bufferSize() < $size) {
             return \false;
         }
         if ($size === 0) {
@@ -293,7 +294,7 @@ class CodedInputStream
     public function incrementRecursionDepthAndPushLimit($byte_limit, &$old_limit, &$recursion_budget)
     {
         $old_limit = $this->pushLimit($byte_limit);
-        $recursion_limit = --$this->recursion_limit;
+        $recursion_budget = --$this->recursion_budget;
     }
     public function decrementRecursionDepthAndPopLimit($byte_limit)
     {

--- a/8.3/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedOutputStream.php
+++ b/8.3/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedOutputStream.php
@@ -82,7 +82,7 @@ class CodedOutputStream
             $low = $value;
         }
         while ($low >= 0x80 || $low < 0 || $high != 0) {
-            $buffer[$current] = chr($low | 0x80);
+            $buffer[$current] = chr(($low | 0x80) & 0xFF);
             $value = $value >> 7 & ~(0x7f << (\PHP_INT_SIZE << 3) - 7);
             $carry = ($high & 0x7f) << (\PHP_INT_SIZE << 3) - 7;
             $high = $high >> 7 & ~(0x7f << (\PHP_INT_SIZE << 3) - 7);

--- a/8.3/vendor/google/protobuf/src/Google/Protobuf/Internal/Descriptor.php
+++ b/8.3/vendor/google/protobuf/src/Google/Protobuf/Internal/Descriptor.php
@@ -46,7 +46,7 @@ class Descriptor
     public function addField($field)
     {
         $this->field[$field->getNumber()] = $field;
-        $this->json_to_field[$field->getJsonName()] = $field;
+        $this->json_to_field[$field->getJsonName() ?? ''] = $field;
         $this->name_to_field[$field->getName()] = $field;
         $this->index_to_field[] = $field;
     }

--- a/8.3/vendor/google/protobuf/src/Google/Protobuf/Internal/DescriptorPool.php
+++ b/8.3/vendor/google/protobuf/src/Google/Protobuf/Internal/DescriptorPool.php
@@ -62,8 +62,8 @@ class DescriptorPool
         $this->proto_to_class[$descriptor->getFullName()] = $descriptor->getClass();
         $this->unique_descs[$descriptor->getFullName()] = $descriptor;
         $this->class_to_desc[$descriptor->getClass()] = $descriptor;
-        $this->class_to_desc[$descriptor->getLegacyClass()] = $descriptor;
-        $this->class_to_desc[$descriptor->getPreviouslyUnreservedClass()] = $descriptor;
+        $this->class_to_desc[$descriptor->getLegacyClass() ?? ''] = $descriptor;
+        $this->class_to_desc[$descriptor->getPreviouslyUnreservedClass() ?? ''] = $descriptor;
         foreach ($descriptor->getNestedType() as $nested_type) {
             $this->addDescriptor($nested_type);
         }
@@ -75,7 +75,7 @@ class DescriptorPool
     {
         $this->proto_to_class[$descriptor->getFullName()] = $descriptor->getClass();
         $this->class_to_enum_desc[$descriptor->getClass()] = $descriptor;
-        $this->class_to_enum_desc[$descriptor->getLegacyClass()] = $descriptor;
+        $this->class_to_enum_desc[$descriptor->getLegacyClass() ?? ''] = $descriptor;
     }
     public function getDescriptorByClassName($klass)
     {

--- a/8.4/composer.lock
+++ b/8.4/composer.lock
@@ -1264,23 +1264,23 @@
     },
     {
       "name": "google/protobuf",
-      "version": "v4.33.4",
+      "version": "v4.33.6",
       "source": {
         "type": "git",
         "url": "https://github.com/protocolbuffers/protobuf-php.git",
-        "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402"
+        "reference": "84b008c23915ed94536737eae46f41ba3bccfe67"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/22d28025cda0d223a2e48c2e16c5284ecc9f5402",
-        "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402",
+        "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/84b008c23915ed94536737eae46f41ba3bccfe67",
+        "reference": "84b008c23915ed94536737eae46f41ba3bccfe67",
         "shasum": ""
       },
       "require": {
         "php": ">=8.1.0"
       },
       "require-dev": {
-        "phpunit/phpunit": ">=5.0.0 <8.5.27"
+        "phpunit/phpunit": ">=10.5.62 <11.0.0"
       },
       "suggest": {
         "ext-bcmath": "Need to support JSON deserialization"
@@ -1302,9 +1302,9 @@
         "proto"
       ],
       "support": {
-        "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.4"
+        "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.6"
       },
-      "time": "2026-01-12T17:58:43+00:00"
+      "time": "2026-03-18T17:32:05+00:00"
     },
     {
       "name": "graham-campbell/result-type",

--- a/8.4/vendor/composer/installed.json
+++ b/8.4/vendor/composer/installed.json
@@ -1318,29 +1318,29 @@
         },
         {
             "name": "google/protobuf",
-            "version": "v4.33.4",
-            "version_normalized": "4.33.4.0",
+            "version": "v4.33.6",
+            "version_normalized": "4.33.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402"
+                "reference": "84b008c23915ed94536737eae46f41ba3bccfe67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/22d28025cda0d223a2e48c2e16c5284ecc9f5402",
-                "reference": "22d28025cda0d223a2e48c2e16c5284ecc9f5402",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/84b008c23915ed94536737eae46f41ba3bccfe67",
+                "reference": "84b008c23915ed94536737eae46f41ba3bccfe67",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=5.0.0 <8.5.27"
+                "phpunit/phpunit": ">=10.5.62 <11.0.0"
             },
             "suggest": {
                 "ext-bcmath": "Need to support JSON deserialization"
             },
-            "time": "2026-01-12T17:58:43+00:00",
+            "time": "2026-03-18T17:32:05+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -1359,7 +1359,7 @@
                 "proto"
             ],
             "support": {
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.4"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.6"
             },
             "install-path": "../google/protobuf"
         },

--- a/8.4/vendor/composer/installed.php
+++ b/8.4/vendor/composer/installed.php
@@ -275,9 +275,9 @@
             'dev_requirement' => false,
         ),
         'google/protobuf' => array(
-            'pretty_version' => 'v4.33.4',
-            'version' => '4.33.4.0',
-            'reference' => '22d28025cda0d223a2e48c2e16c5284ecc9f5402',
+            'pretty_version' => 'v4.33.6',
+            'version' => '4.33.6.0',
+            'reference' => '84b008c23915ed94536737eae46f41ba3bccfe67',
             'type' => 'library',
             'install_path' => __DIR__ . '/../google/protobuf',
             'aliases' => array(),

--- a/8.4/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedInputStream.php
+++ b/8.4/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedInputStream.php
@@ -237,7 +237,8 @@ class CodedInputStream
     public function readRaw($size, &$buffer)
     {
         $current_buffer_size = 0;
-        if ($this->bufferSize() < $size) {
+        // size (varint) read from the wire could be negative.
+        if ($size < 0 || $this->bufferSize() < $size) {
             return \false;
         }
         if ($size === 0) {
@@ -293,7 +294,7 @@ class CodedInputStream
     public function incrementRecursionDepthAndPushLimit($byte_limit, &$old_limit, &$recursion_budget)
     {
         $old_limit = $this->pushLimit($byte_limit);
-        $recursion_limit = --$this->recursion_limit;
+        $recursion_budget = --$this->recursion_budget;
     }
     public function decrementRecursionDepthAndPopLimit($byte_limit)
     {

--- a/8.4/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedOutputStream.php
+++ b/8.4/vendor/google/protobuf/src/Google/Protobuf/Internal/CodedOutputStream.php
@@ -82,7 +82,7 @@ class CodedOutputStream
             $low = $value;
         }
         while ($low >= 0x80 || $low < 0 || $high != 0) {
-            $buffer[$current] = chr($low | 0x80);
+            $buffer[$current] = chr(($low | 0x80) & 0xFF);
             $value = $value >> 7 & ~(0x7f << (\PHP_INT_SIZE << 3) - 7);
             $carry = ($high & 0x7f) << (\PHP_INT_SIZE << 3) - 7;
             $high = $high >> 7 & ~(0x7f << (\PHP_INT_SIZE << 3) - 7);

--- a/8.4/vendor/google/protobuf/src/Google/Protobuf/Internal/Descriptor.php
+++ b/8.4/vendor/google/protobuf/src/Google/Protobuf/Internal/Descriptor.php
@@ -46,7 +46,7 @@ class Descriptor
     public function addField($field)
     {
         $this->field[$field->getNumber()] = $field;
-        $this->json_to_field[$field->getJsonName()] = $field;
+        $this->json_to_field[$field->getJsonName() ?? ''] = $field;
         $this->name_to_field[$field->getName()] = $field;
         $this->index_to_field[] = $field;
     }

--- a/8.4/vendor/google/protobuf/src/Google/Protobuf/Internal/DescriptorPool.php
+++ b/8.4/vendor/google/protobuf/src/Google/Protobuf/Internal/DescriptorPool.php
@@ -62,8 +62,8 @@ class DescriptorPool
         $this->proto_to_class[$descriptor->getFullName()] = $descriptor->getClass();
         $this->unique_descs[$descriptor->getFullName()] = $descriptor;
         $this->class_to_desc[$descriptor->getClass()] = $descriptor;
-        $this->class_to_desc[$descriptor->getLegacyClass()] = $descriptor;
-        $this->class_to_desc[$descriptor->getPreviouslyUnreservedClass()] = $descriptor;
+        $this->class_to_desc[$descriptor->getLegacyClass() ?? ''] = $descriptor;
+        $this->class_to_desc[$descriptor->getPreviouslyUnreservedClass() ?? ''] = $descriptor;
         foreach ($descriptor->getNestedType() as $nested_type) {
             $this->addDescriptor($nested_type);
         }
@@ -75,7 +75,7 @@ class DescriptorPool
     {
         $this->proto_to_class[$descriptor->getFullName()] = $descriptor->getClass();
         $this->class_to_enum_desc[$descriptor->getClass()] = $descriptor;
-        $this->class_to_enum_desc[$descriptor->getLegacyClass()] = $descriptor;
+        $this->class_to_enum_desc[$descriptor->getLegacyClass() ?? ''] = $descriptor;
     }
     public function getDescriptorByClassName($klass)
     {


### PR DESCRIPTION
## Summary

Cherry-pick of #22 to `releases/v0.3.x`.

Update `google/protobuf` from v4.33.4 to v4.33.6 across all PHP version bundles (8.1, 8.2, 8.3, 8.4) to fix high severity vulnerability [GHSA-p2gh-cfq4-4wjc](https://github.com/advisories/GHSA-p2gh-cfq4-4wjc).

## Vulnerability Fixed

| Severity | CVE/GHSA | Package | Previous | Fixed |
|----------|----------|---------|----------|-------|
| **High** | GHSA-p2gh-cfq4-4wjc | google/protobuf | v4.33.4 | v4.33.6 |

## Changes

- `8.1/composer.lock` — google/protobuf v4.33.4 → v4.33.6
- `8.2/composer.lock` — google/protobuf v4.33.4 → v4.33.6
- `8.3/composer.lock` — google/protobuf v4.33.4 → v4.33.6
- `8.4/composer.lock` — google/protobuf v4.33.4 → v4.33.6

Linear: RUN-624