### PR TITLE
ci: add PR policy and release note template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+#### What this PR does / why we need it:
+<!--
+Please add a meaningful description for future maintainers on what this change does and why we need it.
+-->
+
+#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
+<!--
+This section will go in the release notes for this version. Is this something users should be able to find easily?
+If no, just write "NONE" in the release-note block below.
+If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
+-->
+
+```release-note
+
+```

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -14,3 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - uses: odigos-io/ci-core/require-linear@main
+
+  release-note:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: odigos-io/ci-core/require-release-note@main


### PR DESCRIPTION
## Summary
- Add PR policy checks for linked Linear issues and release-note blocks where needed.
- Add the standard Odigos PR template so release-note guidance is present when opening PRs.

## Notes
- Branch protection changes are handled separately after these PRs are reviewed and merged.

```release-note
NONE
```
