### PR TITLE
[v0.4.x] RUN-937: Rename ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS to ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS

### DIFF
--- a/8.1/CustomInstrumentation.php
+++ b/8.1/CustomInstrumentation.php
@@ -16,14 +16,14 @@ use Throwable;
 /**
  * Registers OpenTelemetry hooks for user-configured PHP custom instrumentation probes.
  *
- * Probe configuration is delivered by Odigos via the ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS
+ * Probe configuration is delivered by Odigos via the ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS
  * environment variable (JSON matching the CustomInstrumentations API shape).
  */
 final class Registrar
 {
     public const NAME = 'odigos-custom';
 
-    private const ENV_VAR = 'ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS';
+    private const ENV_VAR = 'ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS';
 
     public static function register(): void
     {

--- a/8.1/odigos_autoload.php
+++ b/8.1/odigos_autoload.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  *
  * Loaded via auto_prepend_file. First loads Composer autoload (community
  * auto-instrumentation packages), then registers Odigos custom instrumentation
- * hooks from ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS.
+ * hooks from ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS.
  */
 
 require_once __DIR__ . '/vendor/autoload.php';

--- a/8.2/CustomInstrumentation.php
+++ b/8.2/CustomInstrumentation.php
@@ -16,14 +16,14 @@ use Throwable;
 /**
  * Registers OpenTelemetry hooks for user-configured PHP custom instrumentation probes.
  *
- * Probe configuration is delivered by Odigos via the ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS
+ * Probe configuration is delivered by Odigos via the ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS
  * environment variable (JSON matching the CustomInstrumentations API shape).
  */
 final class Registrar
 {
     public const NAME = 'odigos-custom';
 
-    private const ENV_VAR = 'ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS';
+    private const ENV_VAR = 'ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS';
 
     public static function register(): void
     {

--- a/8.2/odigos_autoload.php
+++ b/8.2/odigos_autoload.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  *
  * Loaded via auto_prepend_file. First loads Composer autoload (community
  * auto-instrumentation packages), then registers Odigos custom instrumentation
- * hooks from ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS.
+ * hooks from ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS.
  */
 
 require_once __DIR__ . '/vendor/autoload.php';

--- a/8.3/CustomInstrumentation.php
+++ b/8.3/CustomInstrumentation.php
@@ -16,14 +16,14 @@ use Throwable;
 /**
  * Registers OpenTelemetry hooks for user-configured PHP custom instrumentation probes.
  *
- * Probe configuration is delivered by Odigos via the ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS
+ * Probe configuration is delivered by Odigos via the ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS
  * environment variable (JSON matching the CustomInstrumentations API shape).
  */
 final class Registrar
 {
     public const NAME = 'odigos-custom';
 
-    private const ENV_VAR = 'ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS';
+    private const ENV_VAR = 'ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS';
 
     public static function register(): void
     {

--- a/8.3/odigos_autoload.php
+++ b/8.3/odigos_autoload.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  *
  * Loaded via auto_prepend_file. First loads Composer autoload (community
  * auto-instrumentation packages), then registers Odigos custom instrumentation
- * hooks from ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS.
+ * hooks from ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS.
  */
 
 require_once __DIR__ . '/vendor/autoload.php';

--- a/8.4/CustomInstrumentation.php
+++ b/8.4/CustomInstrumentation.php
@@ -16,14 +16,14 @@ use Throwable;
 /**
  * Registers OpenTelemetry hooks for user-configured PHP custom instrumentation probes.
  *
- * Probe configuration is delivered by Odigos via the ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS
+ * Probe configuration is delivered by Odigos via the ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS
  * environment variable (JSON matching the CustomInstrumentations API shape).
  */
 final class Registrar
 {
     public const NAME = 'odigos-custom';
 
-    private const ENV_VAR = 'ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS';
+    private const ENV_VAR = 'ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS';
 
     public static function register(): void
     {

--- a/8.4/odigos_autoload.php
+++ b/8.4/odigos_autoload.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  *
  * Loaded via auto_prepend_file. First loads Composer autoload (community
  * auto-instrumentation packages), then registers Odigos custom instrumentation
- * hooks from ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS.
+ * hooks from ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS.
  */
 
 require_once __DIR__ . '/vendor/autoload.php';

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To deploy an agent & auto-instrument PHP with OpenTelemetry, we need a few thing
 
 3. We need to tell the instrumented app where to find our script and binaries, to do that we need to give the container an env called `PHP_INI_SCAN_DIR`, it should point at the dir that contains the agent files (e.g `:/var/odigos/php/8.2`).
 
-4. Optional: to enable Custom Instrumentation Rule probes, Odigos injects `ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS` with a JSON payload of PHP class/function probes. Changes require a pod restart.
+4. Optional: to enable Custom Instrumentation Rule probes, Odigos injects `ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS` with a JSON payload of PHP class/function probes. Changes require a pod restart.
 
 NOTE: for step 3 we used a colon at the start of the appointed dir, that is required by the env itself, here's why:
 

--- a/_helpers/CustomInstrumentation.php
+++ b/_helpers/CustomInstrumentation.php
@@ -16,14 +16,14 @@ use Throwable;
 /**
  * Registers OpenTelemetry hooks for user-configured PHP custom instrumentation probes.
  *
- * Probe configuration is delivered by Odigos via the ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS
+ * Probe configuration is delivered by Odigos via the ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS
  * environment variable (JSON matching the CustomInstrumentations API shape).
  */
 final class Registrar
 {
     public const NAME = 'odigos-custom';
 
-    private const ENV_VAR = 'ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS';
+    private const ENV_VAR = 'ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS';
 
     public static function register(): void
     {

--- a/_helpers/odigos_autoload.php
+++ b/_helpers/odigos_autoload.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  *
  * Loaded via auto_prepend_file. First loads Composer autoload (community
  * auto-instrumentation packages), then registers Odigos custom instrumentation
- * hooks from ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS.
+ * hooks from ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS.
  */
 
 require_once __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### What this PR does / why we need it:
Cherry-pick of `b3279edd` (#30) onto `releases/v0.4.x`.

Renames the PHP custom instrumentation environment variable from `ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS` to `ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS` so it is language-scoped for the PHP agent.

Fixes [RUN-937](https://linear.app/odigos/issue/RUN-937/rename-odigos-agent-custom-instrumentations-to-odigos-php-agent-custom).

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
Rename custom instrumentation env var from ODIGOS_AGENT_CUSTOM_INSTRUMENTATIONS to ODIGOS_PHP_AGENT_CUSTOM_INSTRUMENTATIONS.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a594ef6-a1d4-458c-8ebc-5cffadeebeee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a594ef6-a1d4-458c-8ebc-5cffadeebeee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

